### PR TITLE
Added https web proxy support to github_asset resource

### DIFF
--- a/libraries/github_asset.rb
+++ b/libraries/github_asset.rb
@@ -76,11 +76,9 @@ module GithubCB
 
       proxy_uri = ENV['https_proxy'] ? URI.parse(ENV['https_proxy']) : URI('')
       proxy_uri = URI.parse(ENV['HTTPS_PROXY']) if ENV['HTTPS_PROXY']
-      p_addr = proxy_uri.host if proxy_uri.host
-      p_port = proxy_uri.port if proxy_uri.port
       p_user, p_pass = proxy_uri.userinfo.split(/:/) if proxy_uri.userinfo
       uri = URI(asset_url(options))
-      res = Net::HTTP::Proxy(p_addr, p_port, p_user, p_pass).start(uri.hostname, uri.port, use_ssl: true) do |http|
+      res = Net::HTTP::Proxy(proxy_uri.host, proxy_uri.port, p_user, p_pass).start(uri.hostname, uri.port, use_ssl: true) do |http|
         req                  = Net::HTTP::Get.new(uri.to_s)
         req['Authorization'] = "token #{options[:token]}" unless options[:token].nil?
         req['Accept']        = "application/octet-stream"


### PR DESCRIPTION
The github_asset resource could not download files if you were using it behind a web proxy. I added support for detecting and using a web proxy by checking the standard proxy environment variables. If those variables are unset, the resource will behave the same as before.
