### PR TITLE
Stopped using constants for default host values

### DIFF
--- a/libraries/github_archive.rb
+++ b/libraries/github_archive.rb
@@ -28,7 +28,7 @@ module GithubCB
       @fqrn                = fqrn
       @organization, @repo = fqrn.split('/')
       @version             = options[:version] ||= "master"
-      @host                = options[:host] ||= default_host
+      @host                = options[:host] ||= self.class.default_host
     end
 
     # @option options [String] :user

--- a/libraries/github_asset.rb
+++ b/libraries/github_asset.rb
@@ -39,7 +39,7 @@ module GithubCB
       @organization, @repo = fqrn.split('/')
       @tag_name            = options[:release]
       @name                = options[:name]
-      @host                = options[:host] ||= default_host
+      @host                = options[:host] ||= self.class.default_host
     end
 
     def asset_url(options)


### PR DESCRIPTION
This fixes https://github.com/reset/github-cookbook/issues/4

Declaring constants in library files throws warning messages when they are "redefined" with each use of the file. I don't see any reason for these values to be constants.

```
/libraries/github_archive.rb:15: warning: already initialized constant DEFAULT_HOST
/libraries/github_asset.rb:26: warning: already initialized constant DEFAULT_HOST
```
