### PR TITLE
Make documentation clearer and add an example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,21 +8,37 @@ A Library Cookbook for interacting with the Github API
 
 ## github_asset Resource/Provider
 
-Downloads an asset from a Github release
+Downloads an asset from a Github release. This resource *only* downloads the file (does not copy it), and its information (including the path to the downloaded file) is returned.
+
+It is up to you to provide commands that make use of the file. See example below.
 
 ### Actions
 
-- **download** - downloads the asset from the Github releaseto disk. (default)
+- **download** - downloads the asset from the Github release to disk. (default)
 
 ### Parameter Attributes
 
 - **name** - name of the asset to download (name attribute)
-- **release** - name of the release the asset is a part of
+- **release** - name of the release the asset is a part of (the git tag of the release)
 - **repo** - repository the release is a part of (required for private repositories)
 - **github_token** - Github token to perform the download with (required for private repositories)
 - **owner** - owner of the downloaded asset on disk
 - **group** - group of the downloaded asset on disk
 - **force** - force downloading even if the asset already exists on disk
+
+## Example
+
+```ruby
+asset = github_asset "berkshelf-api.tar.gz" do
+  repo "berkshelf/berkshelf-api"
+  release "v1.2.1"
+end
+
+execute "Copy #{asset.asset_path} to output folder" do
+  command "cp #{asset.asset_path} #{node["myapp"]["outputfolder"]}"
+end
+
+```
 
 ## HTTP proxy support
 


### PR DESCRIPTION
This will save people time and avoid confusion and the misconception that you can specify the location the provider downloads to.
