### PR TITLE
Add support for retries, retry delay and checksums

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ bin/*
 .kitchen/
 .kitchen.local.yml
 /tmp
+
+vendor/*

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--require spec_helper

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,3 @@
-source "http://api.berkshelf.com"
+source "https://supermarket.chef.io"
 
 metadata

--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,5 @@ group :test do
   gem 'guard-spork', platforms: :ruby
   gem 'coolline'
   gem 'fuubar'
+  gem 'rspec-its'
 end

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Downloads an asset from a Github release
 - **owner** - owner of the downloaded asset on disk
 - **group** - group of the downloaded asset on disk
 - **force** - force downloading even if the asset already exists on disk
+- **retries** - number of times to retry download
+- **retry_delay** - number of seconds between attempts to download file
+- **checksum** - SHA-256 of file, if the checksum does not match, the file is not used
 
 ## HTTP proxy support
 

--- a/chefignore
+++ b/chefignore
@@ -94,3 +94,6 @@ Vagrantfile
 # Travis #
 ##########
 .travis.yml
+
+vendor
+vendor/*

--- a/libraries/github_archive.rb
+++ b/libraries/github_archive.rb
@@ -33,7 +33,6 @@ module GithubCB
 
     # @param [String] filepath
     def file_checksum filepath
-      puts filepath
       Digest::SHA256.file(filepath.to_s).hexdigest
     end
 
@@ -85,6 +84,7 @@ module GithubCB
         end
       end
     rescue GithubCB::ChecksumMismatch => ex
+      FileUtils.rm_rf(options[:path])
       puts "Failed Checksum, Retries left #{options[:retries]}"
       if options[:retries] <= 0
         fail ex

--- a/libraries/github_archive.rb
+++ b/libraries/github_archive.rb
@@ -31,9 +31,24 @@ module GithubCB
       @host                = options[:host] ||= self.class.default_host
     end
 
+    # @param [String] filepath
+    def file_checksum filepath
+      puts filepath
+      Digest::SHA256.file(filepath.to_s).hexdigest
+    end
+
+    # @param [String] expected
+    # @param [String] actual
+    def valid_checksum? expected, actual
+      expected == actual
+    end
+
     # @option options [String] :user
     # @option options [String] :token
     # @option options [Boolean] :force
+    # @option options [Integer] :retries
+    # @option options [Integer] :retry_delay
+    # @option options [String] :checksum
     def download(options = {})
       if options[:force]
         FileUtils.rm_rf(local_archive_path)
@@ -45,12 +60,41 @@ module GithubCB
       open(download_uri, http_basic_authentication: [options[:user], options[:token]]) do |source|
         IO.copy_stream(source, file)
       end
+
+      unless options[:checksum].nil?
+        checksum = file_checksum(options[:path])
+        fail GithubCB::ChecksumMismatch.new(options[:checksum], checksum) unless valid_checksum? options[:checksum], checksum
+      end
+
+      true
     rescue OpenURI::HTTPError => ex
+      FileUtils.rm_rf(options[:path])
       case ex.message
       when /406 Not Acceptable/
         raise GithubCB::AuthenticationError
       else
-        raise ex
+        if options[:retries] <= 0
+          raise ex
+        else
+          options[:retries] -= 1
+          puts "Retrying Download"
+          if options[:retry_delay] > 0
+            sleep options[:retry_delay]
+          end
+          download options
+        end
+      end
+    rescue GithubCB::ChecksumMismatch => ex
+      puts "Failed Checksum, Retries left #{options[:retries]}"
+      if options[:retries] <= 0
+        fail ex
+      else
+        options[:retries] -= 1
+        puts "Retrying Download"
+        if options[:retry_delay] > 0
+          sleep options[:retry_delay]
+        end
+        download options
       end
     ensure
       file.close unless file.nil?

--- a/libraries/github_asset.rb
+++ b/libraries/github_asset.rb
@@ -50,16 +50,12 @@ module GithubCB
         c.access_token = options[:token]
       end
 
-      release = Octokit.releases(fqrn).find do |release|
-        release.tag_name == tag_name
-      end
-
+      release = Octokit.release_for_tag(fqrn, tag_name)
       raise GithubCB::ReleaseNotFound, "release not found" if release.nil?
 
-      asset = release.rels[:assets].get.data.find do |asset|
+      asset = release[:assets].find do |asset|
         asset.name == name
       end
-
       raise GithubCB::AssetNotFound, "asset not found" if asset.nil?
 
       asset.rels[:self].href

--- a/libraries/github_asset.rb
+++ b/libraries/github_asset.rb
@@ -67,7 +67,6 @@ module GithubCB
 
     # @param [String] filepath
     def file_checksum filepath
-      puts filepath
       Digest::SHA256.file(filepath.to_s).hexdigest
     end
 
@@ -132,6 +131,7 @@ module GithubCB
         end
       end
     rescue GithubCB::ChecksumMismatch => ex
+      FileUtils.rm_rf(options[:path])
       puts "Failed Checksum, Retries left #{options[:retries]}"
       if options[:retries] <= 0
         fail ex

--- a/libraries/github_errors.rb
+++ b/libraries/github_errors.rb
@@ -13,6 +13,16 @@ module GithubCB
     end
   end
 
+  class ChecksumMismatch < GHError
+    attr_reader :expected
+    attr_reader :actual
+    def initialize(expected="", actual="")
+      @expected = expected
+      @actual = actual
+      super("expected: #{expected}, actual: #{actual}")
+    end
+  end
+
   class ReleaseNotFound < GHError; end
   class AssetNotFound < GHError; end
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,4 +8,4 @@ version          "0.3.2"
 
 supports "ubuntu"
 
-depends "libarchive"
+depends "libarchive", "~> 0.4.1"

--- a/providers/archive.rb
+++ b/providers/archive.rb
@@ -21,7 +21,8 @@ action :extract do
   unless !new_resource.force || archive.downloaded?
     Chef::Log.info "github_archive[#{new_resource.name}] downloading archive"
     archive.download(user: new_resource.github_user, token: new_resource.github_token,
-      force: new_resource.force)
+      force: new_resource.force, retries: new_resource.retries,
+      retry_delay: new_resource.retry_delay, checksum: new_resource.checksum)
     new_resource.updated_by_last_action(true)
   end
 

--- a/providers/asset.rb
+++ b/providers/asset.rb
@@ -27,7 +27,8 @@ action :download do
 
   Chef::Log.info "github_asset[#{new_resource.name}] downloading asset"
   updated = asset.download(user: new_resource.github_user, token: new_resource.github_token,
-    force: new_resource.force, path: new_resource.asset_path)
+    force: new_resource.force, path: new_resource.asset_path, retries: new_resource.retries,
+    retry_delay: new_resource.retry_delay, checksum: new_resource.checksum)
   new_resource.updated_by_last_action(updated)
 end
 

--- a/providers/deploy.rb
+++ b/providers/deploy.rb
@@ -35,6 +35,9 @@ action :deploy do
     host         new_resource.host
     extract_to   new_resource.deploy_path
     force        @should_force
+    retries      new_resource.retries
+    retry_delay  new_resource.retry_delay
+    checksum     new_resource.checksum
 
     if @should_force
       action [ :delete, :extract ]

--- a/resources/archive.rb
+++ b/resources/archive.rb
@@ -17,3 +17,6 @@ attribute :owner, kind_of: String
 attribute :group, kind_of: String
 attribute :extract_to, kind_of: String, required: true
 attribute :force, kind_of: [TrueClass, FalseClass], default: false
+attribute :retries, kind_of: Integer, default: 2
+attribute :retry_delay, kind_of: Integer, default: 1
+attribute :checksum, kind_of: String

--- a/resources/asset.rb
+++ b/resources/asset.rb
@@ -16,6 +16,10 @@ attribute :github_token, kind_of: String
 attribute :owner, kind_of: String
 attribute :group, kind_of: String
 attribute :force, kind_of: [TrueClass, FalseClass], default: false
+attribute :retries, kind_of: Integer, default: 2
+attribute :retry_delay, kind_of: Integer, default: 1
+attribute :checksum, kind_of: String
+
 
 def asset_path
   GithubCB::Asset.asset_path(@repo, @release, @name)

--- a/resources/deploy.rb
+++ b/resources/deploy.rb
@@ -18,6 +18,9 @@ attribute :owner, kind_of: String
 attribute :group, kind_of: String
 attribute :shared_directories, kind_of: Array, default: [ "pids", "log" ]
 attribute :force, kind_of: [TrueClass, FalseClass], default: false
+attribute :retries, kind_of: Integer, default: 2
+attribute :retry_delay, kind_of: Integer, default: 1
+attribute :checksum, kind_of: String
 
 attribute :configure, kind_of: Proc
 attribute :before_migrate, kind_of: Proc

--- a/spec/libraries/github_archive_spec.rb
+++ b/spec/libraries/github_archive_spec.rb
@@ -37,7 +37,7 @@ describe GithubCB::Archive do
       target = File.join(Chef::Config[:file_cache_path],
         "github_deploy", "archives", "berkshelf-cookbook-master.tar.gz")
 
-      expect(File.exist?(target)).to be_true
+      expect(File.exist?(target)).to be_truthy
     end
   end
 
@@ -46,13 +46,13 @@ describe GithubCB::Archive do
       before { subject.download }
 
       it "returns true" do
-        expect(subject.downloaded?).to be_true
+        expect(subject.downloaded?).to be_truthy
       end
     end
 
     context "when it is not present on disk" do
       it "returns false" do
-        expect(subject.downloaded?).to be_false
+        expect(subject.downloaded?).to be_falsey
       end
     end
   end
@@ -63,7 +63,7 @@ describe GithubCB::Archive do
 
     it "extracts the contents of the archive into the target directory" do
       subject.extract(target)
-      expect(File.exist?(File.join(target, "metadata.rb"))).to be_true
+      expect(File.exist?(File.join(target, "metadata.rb"))).to be_truthy
     end
   end
 end

--- a/spec/libraries/github_asset_spec.rb
+++ b/spec/libraries/github_asset_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe GithubCB::Asset do
+  describe "ClassMethods" do
+    describe "::new" do
+      let(:fqrn) { "berkshelf/berkshelf-cookbook" }
+      let(:options) { {
+        :release => "v0.3.1",
+        :name => "cookbooks.tar.gz"
+      } }
+      subject { described_class.new(fqrn, options) }
+
+      its(:organization) { should eq("berkshelf") }
+      its(:repo) { should eq("berkshelf-cookbook") }
+      its(:host) { should eq("https://github.com") }
+      its(:tag_name) { should eq("v0.3.1") }
+      its(:name) { should eq("cookbooks.tar.gz") }
+    end
+  end
+
+  subject { described_class.new("berkshelf/berkshelf-cookbook", {
+    :release => "v0.3.1",
+    :name => "cookbooks.tar.gz"
+  })}
+
+  describe "#asset_url" do
+    let(:options) { {
+    } }
+    it "gets the url of the asset" do
+        expect(subject.asset_url(options)).not_to be_empty
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require 'bundler'
 require 'rspec'
 require 'spork'
 require 'chef'
+require 'rspec/its'
 
 Spork.prefork do
   Dir[File.join(File.expand_path("../../spec/support/**/*.rb", __FILE__))].each { |f| require f }
@@ -13,7 +14,6 @@ Spork.prefork do
     end
 
     config.mock_with :rspec
-    config.treat_symbols_as_metadata_keys_with_true_values = true
     config.filter_run focus: true
     config.run_all_when_everything_filtered = true
 


### PR DESCRIPTION
We are getting failed downloads from GitHub all the time. I added support for retries with a delay and checksum verification.

(I hope this solves my problem)
