### PR TITLE
Add :extract action to github_asset resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ This file is used to list changes made in each version of the GitHub cookbook.
 
 ## Unreleased
 
+- Add :extract action to github_asset resource
+
 ## 1.0.1 - *2021-11-02*
+
+- Fix typo
 
 ## 1.0.0 - *2021-09-08*
 

--- a/documentation/asset.md
+++ b/documentation/asset.md
@@ -6,10 +6,11 @@ Downloads an asset from a Github repository
 
 ## Actions
 
-| Action      | Description                                    |
-| ----------- | ---------------------------------------------- |
-| `:download` | Downloads an asset from a Github repository    |
-| `:delete`   | Deletes a local asset from a Github repository |
+| Action      | Description                                              |
+| ----------- | -------------------------------------------------------- |
+| `:download` | Downloads an asset from a Github repository              |
+| `:extract`  | Downloads and extracts an asset from a Github repository |
+| `:delete`   | Deletes a local asset from a Github repository           |
 
 ## Properties
 
@@ -23,6 +24,7 @@ Downloads an asset from a Github repository
 | `owner`        | String          |               | Owner for extracted archive              |
 | `group`        | String          |               | Group for extracted archive              |
 | `force`        | `true`, `false` | `false`       | Force downloading and extracting archive |
+| `extract_to`   | String          |               | Path to extract asset to                 |
 
 ## Examples
 
@@ -36,5 +38,12 @@ github_asset 'Precompiled.zip' do
   repo 'elixir-lang/elixir'
   release 'v1.12.2'
   action :delete
+end
+
+github_asset 'Precompiled.zip' do
+  repo 'elixir-lang/elixir'
+  release 'v1.12.2'
+  extract_to '/opt/elixir'
+  action :extract
 end
 ```

--- a/test/fixtures/cookbooks/test/recipes/default.rb
+++ b/test/fixtures/cookbooks/test/recipes/default.rb
@@ -10,6 +10,14 @@ github_asset 'Precompiled.zip-delete' do
   action :delete
 end
 
+github_asset 'Precompiled.zip-extract' do
+  file 'Precompiled.zip'
+  repo 'elixir-lang/elixir'
+  release 'v1.13.0'
+  extract_to '/tmp/extract'
+  action :extract
+end
+
 github_archive 'elixir-lang/elixir' do
   extract_to '/tmp/test'
 end

--- a/test/integration/default/controls/default.rb
+++ b/test/integration/default/controls/default.rb
@@ -3,10 +3,12 @@ cache_dir = inspec.file('/opt/kitchen').exist? ? '/opt/kitchen/cache' : '/tmp/ki
 control 'github-cookbook' do
   [
     "#{cache_dir}/github_assets/elixir-lang/elixir/v1.12.2/Precompiled.zip",
+    "#{cache_dir}/github_assets/elixir-lang/elixir/v1.13.0/Precompiled.zip",
     "#{cache_dir}/github_deploy/archives/elixir-master.tar.gz",
     "#{cache_dir}/github_deploy/archives/elixir-v1.12.tar.gz",
-    '/tmp/test/elixir-master/README.md',
+    '/tmp/test/elixir-main/README.md',
     '/tmp/deploy/releases/v1.12/elixir-1.12/README.md',
+    '/tmp/extract/bin/elixir',
   ].each do |f|
     describe file f do
       it { should exist }


### PR DESCRIPTION
This provides an additional action to `github_asset` which downloads and then extracts the asset using `archive_file` to a path.

This is needed to help sous-chefs/elixir#21

NOTE: I was unsure whether or not we should also delete the `extract_to` path when using the `:delete` action. Adding
this also requires the `extract_to` parameter with `:delete`. I kind of assumed this would be up to the user to manage
in case the path includes other files.

Signed-off-by: Lance Albertson <lance@osuosl.org>
